### PR TITLE
Add authentication provider

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,10 +1,11 @@
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, useEffect, useState } from 'react'
 import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react'
 import { IonReactRouter } from '@ionic/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { Redirect, Route } from 'react-router-dom'
+import { Redirect, Route, useHistory } from 'react-router-dom'
 
 import { Toaster } from '@/components/ui/toaster'
+import { verifySession } from '@/lib/session'
 
 import { Loading } from './components/loading'
 import BranchSelector from './pages/branch-selector'
@@ -25,6 +26,24 @@ const queryClient = new QueryClient()
  * @returns The rendered component.
  */
 export default function App() {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false)
+  const history = useHistory()
+
+  useEffect(() => {
+    async function checkSession() {
+      const session = await verifySession()
+      setIsAuthenticated(session !== null)
+    }
+
+    void checkSession()
+  }, [])
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      history.push('/login')
+    }
+  }, [isAuthenticated, history])
+
   return (
     <QueryClientProvider client={queryClient}>
       <IonApp>

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -93,3 +93,40 @@ export async function deleteSession() {
 
   // Redirect to the login page
 }
+
+/**
+ * Retrieves the session token from cookies.
+ *
+ * @returns A promise that resolves to the session token if found, or null otherwise.
+ */
+export async function getSessionToken(): Promise<string | null> {
+  const cookies = await CapacitorCookies.getCookies()
+  return cookies.session ?? null
+}
+
+/**
+ * Sets the session token in cookies.
+ *
+ * @param token - The session token to set.
+ * @param expiresAt - The expiration date of the session token.
+ * @returns A promise that resolves to void.
+ */
+export async function setSessionToken(token: string, expiresAt: Date): Promise<void> {
+  await CapacitorCookies.setCookie({
+    key: 'session',
+    value: token,
+    path: '/',
+    expires: expiresAt.toString(),
+  })
+}
+
+/**
+ * Clears the session token from cookies.
+ *
+ * @returns A promise that resolves to void.
+ */
+export async function clearSessionToken(): Promise<void> {
+  await CapacitorCookies.deleteCookie({
+    key: 'session',
+  })
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -6,7 +6,7 @@ import { useForm } from 'react-hook-form'
 
 import { authenticateUser } from '@/lib/api'
 import { loginFormSchema, type LoginFormSchema } from '@/lib/form-schema'
-import { createSession } from '@/lib/session'
+import { setSessionToken } from '@/lib/session'
 import { saveToStorage } from '@/lib/storage'
 import { useToast } from '@/hooks/use-toast'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -65,7 +65,8 @@ export default function Login() {
             const userId = user.id
             const userRole = user.level
 
-            await createSession(userId, userRole)
+            const expiresAt = new Date(Date.now() + 60 * 60 * 1000)
+            await setSessionToken(authenticatedUser.data.token, expiresAt)
 
             router.push('/branch-selector')
           } else {


### PR DESCRIPTION
Add an authentication provider for a mobile app using Ionic with Vite and react-router-dom for routing, storing credentials as cookies.

* **src/lib/session.ts**
  - Add `getSessionToken` function to retrieve the session token from cookies.
  - Add `setSessionToken` function to set the session token in cookies.
  - Add `clearSessionToken` function to clear the session token from cookies.

* **src/app.tsx**
  - Import `verifySession` from `src/lib/session.ts`.
  - Add `isAuthenticated` state to track authentication status.
  - Add `useEffect` to verify the session on app load and update `isAuthenticated`.
  - Add conditional rendering to redirect to `/login` if not authenticated.

* **src/pages/login.tsx**
  - Import `setSessionToken` from `src/lib/session.ts`.
  - Update `loginUser` function to use `setSessionToken` instead of `createSession`.
  - Remove import and usage of `createSession`.

