### PR TITLE
Fix configuration file error by renaming "pnpm" to "npm"

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
This pull request makes a minor update to the `.github/dependabot.yaml` file, changing the `package-ecosystem` from "pnpm" to "npm".