### PR TITLE
feat: add useIonViewDidEnter to refetch data

### DIFF
--- a/src/pages/app/daily-count/index.tsx
+++ b/src/pages/app/daily-count/index.tsx
@@ -15,6 +15,7 @@ import {
   IonTitle,
   IonToolbar,
   useIonModal,
+  useIonViewDidEnter,
   type RefresherEventDetail,
 } from "@ionic/react";
 import type { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
@@ -75,6 +76,10 @@ export default function DailyCount() {
       event.detail.complete();
     }
   }
+
+  useIonViewDidEnter(() => {
+    void refetch();
+  });
 
   return (
     <Fragment>

--- a/src/pages/app/delivery/index.tsx
+++ b/src/pages/app/delivery/index.tsx
@@ -15,6 +15,7 @@ import {
   IonTitle,
   IonToolbar,
   useIonModal,
+  useIonViewDidEnter,
   type RefresherEventDetail,
 } from "@ionic/react";
 import type { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
@@ -109,6 +110,10 @@ export default function Delivery() {
       event.detail.complete();
     }
   }
+
+  useIonViewDidEnter(() => {
+    void refetch();
+  });
 
   return (
     <Fragment>

--- a/src/pages/app/expenses/index.tsx
+++ b/src/pages/app/expenses/index.tsx
@@ -12,6 +12,7 @@ import {
   IonTitle,
   IonToolbar,
   useIonModal,
+  useIonViewDidEnter,
 } from "@ionic/react";
 import type { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
 import { add } from "ionicons/icons";
@@ -50,6 +51,10 @@ export default function Expenses() {
       },
     });
   }
+
+  useIonViewDidEnter(() => {
+    console.log("Expenses page loaded");
+  });
 
   return (
     <Fragment>

--- a/src/pages/app/wastes/index.tsx
+++ b/src/pages/app/wastes/index.tsx
@@ -14,6 +14,7 @@ import {
   IonTitle,
   IonToolbar,
   useIonModal,
+  useIonViewDidEnter,
   type RefresherEventDetail,
 } from "@ionic/react";
 import type { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
@@ -84,6 +85,10 @@ export default function Wastes() {
       event.detail.complete();
     }
   }
+
+  useIonViewDidEnter(() => {
+    void refetch();
+  });
 
   return (
     <Fragment>


### PR DESCRIPTION
This pull request includes changes to multiple pages in the application to add the `useIonViewDidEnter` hook for refreshing data or logging when the view is entered. The changes are applied consistently across different pages to ensure a uniform behavior.